### PR TITLE
feat: add bash script to export content and push it to remote git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 content
 site
+stage
 .env
 .DS_store
 config.production.json

--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ $ docker-compose run --rm export
 
 A preview of the static website can be viewed at http://localhost:9999
 
-4. Export the content of Ghost as static files for publishing
+4. Publish the content of Ghost
 
 ```
-$ docker-compose run --rm publish
+$ ./publish
 ```
 
-The static pages are in the ``site`` directory ready to be published to your remote web site
+The static web pages are first exported in the ``public`` directory inside the directory defined by the $PAGES_REPO_PATH variable.
+Then the changes are commited and pushed to the remote git repository.
 
 5. Shutdown the servers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   publish:
     build: .
     volumes:
-      - "./site:/static"
+      - "./$PAGES_REPO_PATH/public:/static"
     command: /usr/local/bin/gssg --url $REMOTE_URL
     extra_hosts:
       - "localhost:172.31.238.10"

--- a/env-sample
+++ b/env-sample
@@ -1,2 +1,3 @@
 # Usage: cp env-sample .env
 REMOTE_URL=
+PAGES_REPO_PATH=stage/gitlab

--- a/publish
+++ b/publish
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+source .env
+
+docker-compose run --rm publish
+
+cd $PAGES_REPO_PATH
+git add -A
+git commit -m "Update on the website at $(date)"
+git push origin master
+cd ..


### PR DESCRIPTION
New variable to define in .env, env-sample: PAGES_REPO_PATH for where is the repo of the static page git based hosting. Created a stage directory for where to put the above repo and make sure it is gitignored (as the content has its own repo).

Create bash script that first export the content using gssg in the public directory inside $PAGES_REPO_PATH, then it will cd into that latter directory and git push to remote repo.

Refs: #4