### PR TITLE
refactor: Use gssg from Docker Hub for immutability and security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
         ipv4_address: 172.31.238.10
 
   export:
-    build:
-      context: .
-      dockerfile: gssg/Dockerfile
+    image: rija/gssg:20230123
     volumes:
       - "./site:/static"
     command: /usr/local/bin/gssg --ignore-absolute-paths --url $REMOTE_URL
@@ -25,9 +23,7 @@ services:
       - app-net
 
   publish:
-    build:
-      context: .
-      dockerfile: gssg/Dockerfile    
+    image: rija/gssg:20230123    
     volumes:
       - "./$PAGES_REPO_PATH/public:/static"
     command: /usr/local/bin/gssg --url $REMOTE_URL


### PR DESCRIPTION
to reduce exposure to supply-chain attacks on NPM, we freeze gssg and its dependencies so we know they are not changing everytime this project is cloned or re-installed.

The first part was to build and push the image to Docker Hub after creating a namespace there. The second part (this commit) is to update our docker-compose file to use the image from Docker hub.

Refs: #9