### PR TITLE
feat: Add preview script to export content for preview and open browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Ghost is now available at http://localhost:2368
 3. Export the content of Ghost as static file for preview
 
 ```
-$ docker-compose run --rm export
+$ ./preview
 ```
 
 A preview of the static website can be viewed at http://localhost:9999

--- a/preview
+++ b/preview
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+source .env
+
+docker-compose run --rm export
+
+PREVIEW_URL=http:localhost:9999
+xdg-open $PREVIEW_URL || sensible-browser $PREVIEW_URL || x-www-browser $PREVIEW_URL || gnome-open $PREVIEW_URL || open $PREVIEW_URL


### PR DESCRIPTION
It is a wrapper around the docker-compose call
```
docker-compose run --rm export
```
with the addition of opening the exported static pages in the default web browser afterward.

Refs: #3