### PR TITLE
Fix issue where the link to the homepage is empty on posts and other pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ A Docker-based pipeline to publish the content of a local Ghost 4 server as stat
 
 ## Prerequisites
 
-You need to have ``Docker`` and ``bash`` installed on your system already.
+You need to have installed on your system already:
+
+* Docker
+* bash
+* git
+* bats-core (optional, for running the test suite) 
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,10 +38,17 @@ services:
       - ./site:/usr/share/nginx/html:ro
     ports:
       - 9999:80
+    networks:
+      - app-net
 
   version:
     image: rija/gssg:20230124
     command: sh -c "echo 'gssg:' && /usr/local/bin/gssg --version && echo 'wget:' && wget --version | head -1 && echo 'Node:' && node --version && echo 'NPM:' && npm --version"
+
+  test:
+    image: bats/bats:1.8.2
+    volumes:
+      - .:/code
 
 networks:
   app-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: rija/gssg:20230124
     volumes:
       - "./site:/static"
-    command: /usr/local/bin/gssg --ignore-absolute-paths --url $REMOTE_URL
+    command: /usr/local/bin/gssg --url http://localhost:9999
     extra_hosts:
       - "localhost:172.31.238.10"
     networks:

--- a/tests/bug-19-homepage-link-empty.bats
+++ b/tests/bug-19-homepage-link-empty.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+setup () {
+	./preview 1> /dev/null 2> /dev/null
+}
+
+@test "link to homepage on other page is not empty" {
+	link=$(docker-compose run --rm export sh -c "wget -qO- http://preview/404/" | grep "gh-head-logo" | cut -d"=" -f3)
+	[[ $link =~ http://localhost:9999 ]]
+}


### PR DESCRIPTION
Thank you for contributing to this project, please fill in the form below to describe the change you want to contribute.

## What issue this PR refers to ?

Refs: #19

(Don't leave this empty, first create a relevant Github issue if you don't have one to reference)

## Summary of the changes

It implements: 

* 5ffeabf feat: add an automated test for the bug
* edd0d0a fix: link to homepage on blog posts in local preview now work

It does so by changing the parameters passed to the ``gssg`` tool when invoked in the ``docker-compose.yml``'s ``export`` container service: 

* Don't use ``--ignore-absolute-paths`` because it's buggy and it's the reason why the anchor element has an empty ``href`` value
* Pass ``--url http://localhost:9999``, because if we don't, it will use the Ghost webapp url wich is not what we want in the preview of static pages

## Conformity

  * [x] I have read, understood and agreed to the terms of the CODE_OF_CONDUCT document
  * [x] I have read, understood and agreed to the terms of the CONTRIBUTING document
  * [x] I have read, understood and agreed to the terms of the SECURITY document
  * [x] I have tested thoroughly the changes on my local environment
  
  Additionally, for changes to documentation:
  
  * [x] I have followed the instructions from the updated documentation and it worked as expected
  * [x] I have proof-read the changes to the documentation for typos, grammar, language level
  
  Additionally, for bug fixes:
  
  * [x] I have reproduced the bug referenced above on my local environment
  * [x] I have tested that the fix addresses the bug on my local environment
  
  Additionally, for new feature, refactoring or complex bugs:
  
  * [ ] I have discussed with the project maintainer the approach and design to the changes prior to implementing them
  * [ ] I have obtained agreement from the project maintainer to proceed with said approach and design
  
  

