### PR TITLE
Create a setup script to configure the project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ services:
   - docker:dind
 
 before_script:
-  - apk add npm bash
+  - apk add npm bash git
   - npm install -g bats
 
 test:

--- a/README.md
+++ b/README.md
@@ -38,27 +38,22 @@ A Docker-based pipeline to publish the content of a local Ghost 4 server as stat
 
 ## Usage
 
-1. First, create an ``.env`` file in the project directory, in which you give a value to the ``REMOTE_URL`` variable:
+1. Run the setup script:
 
 ```
-$ cp env-sample .env
+$ ./setup
 ```
-Then edit .env file to assign a value to ``REMOTE_URL``
+Then edit .env file to assign a value to ``DEST_REPO``, ensure the value for PAGES_REPO_PATH and DEST_BRANCH are correct
 
-2. Then, create a configuration file for the Ghost server
 
-```
-$ cp config.production.json.sample config.production.json
-```
-
-3. Start the two servers (the blog editor and the preview server)
+2. Start the servers (the blog editor and the preview server)
 
 ```
 $ ./up
 ```
 Ghost is now available at http://localhost:2368
 
-4. Export the content of Ghost as static file for preview
+3. Export the content of Ghost as static file for preview
 
 ```
 $ ./preview
@@ -66,7 +61,7 @@ $ ./preview
 
 A preview of the static website can be viewed at http://localhost:9999
 
-5. Publish the content of Ghost
+4. Publish the content of Ghost
 
 ```
 $ ./publish
@@ -75,7 +70,7 @@ $ ./publish
 The static web pages are first exported in the ``public`` directory inside the directory defined by the $PAGES_REPO_PATH variable.
 Then the changes are commited and pushed to the remote git repository.
 
-6. Shutdown the servers
+5. Shutdown the servers
 
 ```
 $ ./down

--- a/README.md
+++ b/README.md
@@ -18,12 +18,23 @@ A Docker-based pipeline to publish the content of a local Ghost 4 server as stat
 
 ## Prerequisites
 
-You need to have installed on your system already:
+1. You need to have installed on your system already:
 
 * Docker
 * bash
 * git
 * bats-core (optional, for running the test suite) 
+
+2. To publish to remote destination, you need to have a git-enabled remote static page hosting setup and configured:
+
+| Host type | Needs done before | More infos |
+| -- | -- | -- |
+| Bitbucket | have created a new repository on Bitbucket.org| https://support.atlassian.com/bitbucket-cloud/docs/publishing-a-website-on-bitbucket-cloud/ |
+| Codeberg | have created a new public repo named "pages" on Codeberg.org | https://docs.codeberg.org/codeberg-pages/ |
+| GitHub | have followed instructions in the docs on Github.com | https://docs.github.com/en/pages/quickstart |
+| GitLab | have created a new project of type "Pages/Plain HTML" on GitLab.com | https://docs.gitlab.com/ee/user/project/pages/ |
+
+>**Disclaimer:** at time of writing, I have only tested with GitLab.com (it may work on other GitLab-based forges - like framagit.org - , not sure for the other ones)
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   publish:
     image: rija/gssg:20230124    
     volumes:
-      - "./$PAGES_REPO_PATH/public:/static"
+      - "./stage/$PAGES_REPO_PATH/public:/static"
     command: /usr/local/bin/gssg --url $REMOTE_URL
     extra_hosts:
       - "localhost:172.31.238.10"

--- a/env-sample
+++ b/env-sample
@@ -1,3 +1,4 @@
 # Usage: cp env-sample .env
 REMOTE_URL=
 PAGES_REPO_PATH=stage/gitlab
+DEST_BRANCH=master

--- a/env-sample
+++ b/env-sample
@@ -2,3 +2,4 @@
 REMOTE_URL=
 PAGES_REPO_PATH=stage/gitlab
 DEST_BRANCH=master
+DEST_REPO=

--- a/env-sample
+++ b/env-sample
@@ -1,5 +1,5 @@
 # Usage: cp env-sample .env
 REMOTE_URL=
-PAGES_REPO_PATH=stage/gitlab
+PAGES_REPO_PATH=gitlab
 DEST_BRANCH=master
 DEST_REPO=

--- a/publish
+++ b/publish
@@ -7,5 +7,5 @@ docker-compose run --rm publish
 cd $PAGES_REPO_PATH
 git add -A
 git commit -m "Update on the website at $(date)"
-git push origin master
+git push origin $DEST_BRANCH
 cd ..

--- a/publish
+++ b/publish
@@ -4,7 +4,7 @@ source .env
 
 docker-compose run --rm publish
 
-cd $PAGES_REPO_PATH
+cd stage/$PAGES_REPO_PATH
 git add -A
 git commit -m "Update on the website at $(date)"
 git push origin $DEST_BRANCH

--- a/setup
+++ b/setup
@@ -8,7 +8,7 @@ configure_ghost $dir
 configure_env $dir
 source .env
 
-
+create_runtime_dirs $dir
 create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO
 
 

--- a/setup
+++ b/setup
@@ -9,6 +9,6 @@ configure_env $dir
 source .env
 
 create_runtime_dirs $dir
-create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO
+create_dir_for_repo "stage/$PAGES_REPO_PATH" $DEST_REPO
 
 

--- a/setup
+++ b/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+source .env
+source ./src/lib/repo_setup.sh
+
+create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO

--- a/setup
+++ b/setup
@@ -5,4 +5,8 @@ set -e
 source .env
 source ./src/lib/repo_setup.sh
 
+
 create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO
+
+
+configure_ghost "."

--- a/setup
+++ b/setup
@@ -2,8 +2,9 @@
 
 set -e
 
-source .env
 source ./src/lib/repo_setup.sh
+configure_env "."
+source .env
 
 
 create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO

--- a/setup
+++ b/setup
@@ -2,12 +2,13 @@
 
 set -e
 
+dir="."
 source ./src/lib/repo_setup.sh
-configure_env "."
+configure_ghost $dir
+configure_env $dir
 source .env
 
 
 create_dir_for_repo $PAGES_REPO_PATH $DEST_REPO
 
 
-configure_ghost "."

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -33,3 +33,10 @@ configure_env () {
 		cp env-sample $envBaseDir/.env
 	fi
 }
+
+create_runtime_dirs () {
+	runtimeDir=$1
+	if [ -d $runtimeDir/site ];then
+		echo "doing nothing, $runtimeDir/site already exists"
+	fi
+}

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+create_dir_for_repo () {
+	pwd
+	baseDir=$1 
+	remoteRepo=$2
+	if [ -d $baseDir ];then
+		echo "doing nothing, $baseDir already exists"
+	 	exit 0
+	else
+		echo "Creating directory..."
+	fi
+}

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -18,7 +18,9 @@ create_dir_for_repo () {
 
 configure_ghost () {
 	baseDir=$1
-	if [ -f config.production.json ];then
+	if [ -f $baseDir/config.production.json ];then
 		echo "doing nothing, the configuration file already exists"
+	else
+		cp config.production.json.sample $baseDir/config.production.json
 	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -4,29 +4,31 @@ set -e
 
 create_dir_for_repo () {
 	pwd
-	baseDir=$1 
+	repoBaseDir=$1 
 	remoteRepo=$2
-	if [ -d $baseDir ];then
-		echo "doing nothing, $baseDir already exists"
+	if [ -d $repoBaseDir ];then
+		echo "doing nothing, $repoBaseDir already exists"
 	elif [ -z $remoteRepo ];then
 		echo "repo cannot be empty"
 	else
 		echo "try cloning $remoteRepo"
-		git clone $remoteRepo $baseDir
+		git clone $remoteRepo $repoBaseDir
 	fi
 }
 
 configure_ghost () {
-	baseDir=$1
-	if [ -f $baseDir/config.production.json ];then
+	ghostBaseDir=$1
+	if [ -f $ghostBaseDir/config.production.json ];then
 		echo "doing nothing, the configuration file already exists"
 	else
-		cp config.production.json.sample $baseDir/config.production.json
+		cp config.production.json.sample $ghostBaseDir/config.production.json
 	fi
 }
 
 configure_env () {
-	if [ -f $baseDir/.env ];then
-		echo "doing nothing, the .env file already exists"
+	if [ -f $envBaseDir/.env ];then
+		echo "doing nothing, file $envBaseDir/.env already exists"
+	else
+		cp env-sample $envBaseDir/.env
 	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -8,8 +8,9 @@ create_dir_for_repo () {
 	remoteRepo=$2
 	if [ -d $baseDir ];then
 		echo "doing nothing, $baseDir already exists"
-	 	exit 0
+	elif [ -z $remoteRepo ];then
+		echo "repo cannot be empty"
 	else
-		echo "Creating directory..."
+		echo "try cloning $remoteRepo"
 	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -24,3 +24,9 @@ configure_ghost () {
 		cp config.production.json.sample $baseDir/config.production.json
 	fi
 }
+
+configure_env () {
+	if [ -f $baseDir/.env ];then
+		echo "doing nothing, the .env file already exists"
+	fi
+}

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -41,4 +41,8 @@ create_runtime_dirs () {
 	else
 		mkdir $runtimeDir/site
 	fi
+
+	if [ -d $runtimeDir/stage ];then
+		echo "doing nothing, $runtimeDir/stage already exists"
+	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -15,3 +15,10 @@ create_dir_for_repo () {
 		git clone $remoteRepo $baseDir
 	fi
 }
+
+configure_ghost () {
+	baseDir=$1
+	if [ -f config.production.json ];then
+		echo "doing nothing, the configuration file already exists"
+	fi
+}

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -26,6 +26,7 @@ configure_ghost () {
 }
 
 configure_env () {
+	envBaseDir=$1
 	if [ -f $envBaseDir/.env ];then
 		echo "doing nothing, file $envBaseDir/.env already exists"
 	else

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -12,5 +12,6 @@ create_dir_for_repo () {
 		echo "repo cannot be empty"
 	else
 		echo "try cloning $remoteRepo"
+		git clone $remoteRepo $baseDir
 	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -38,5 +38,7 @@ create_runtime_dirs () {
 	runtimeDir=$1
 	if [ -d $runtimeDir/site ];then
 		echo "doing nothing, $runtimeDir/site already exists"
+	else
+		mkdir $runtimeDir/site
 	fi
 }

--- a/src/lib/repo_setup.sh
+++ b/src/lib/repo_setup.sh
@@ -3,16 +3,15 @@
 set -e
 
 create_dir_for_repo () {
-	pwd
-	repoBaseDir=$1 
+	repoFullPath=$1 
 	remoteRepo=$2
-	if [ -d $repoBaseDir ];then
-		echo "doing nothing, $repoBaseDir already exists"
+	if [ -d $repoFullPath ];then
+		echo "doing nothing, $repoFullPath already exists"
 	elif [ -z $remoteRepo ];then
 		echo "repo cannot be empty"
 	else
 		echo "try cloning $remoteRepo"
-		git clone $remoteRepo $repoBaseDir
+		git clone $remoteRepo $repoFullPath
 	fi
 }
 
@@ -44,5 +43,7 @@ create_runtime_dirs () {
 
 	if [ -d $runtimeDir/stage ];then
 		echo "doing nothing, $runtimeDir/stage already exists"
+	else
+		mkdir $runtimeDir/stage
 	fi
 }

--- a/tests/configure_env.bats
+++ b/tests/configure_env.bats
@@ -1,0 +1,17 @@
+#!/usr/sbin/env bats
+
+source ./src/lib/repo_setup.sh
+
+
+teardown () {
+	if [ -f tests/.env ];then
+		rm tests/.env
+	fi
+}
+
+@test "do nothing if .env file already exists" {
+	baseDir=tests
+	cp env-sample tests/.env
+	run configure_env $baseDir
+	[[ $output = "doing nothing, the .env file already exists" ]]
+}

--- a/tests/configure_env.bats
+++ b/tests/configure_env.bats
@@ -13,5 +13,11 @@ teardown () {
 	baseDir=tests
 	cp env-sample tests/.env
 	run configure_env $baseDir
-	[[ $output = "doing nothing, the .env file already exists" ]]
+	[[ $output = "doing nothing, file $baseDir/.env already exists" ]]
+}
+
+@test "copy environment config from sample if no .env file exists" {
+	baseDir=tests
+	run configure_env $baseDir
+	[ -f tests/.env ]
 }

--- a/tests/configure_ghost.bats
+++ b/tests/configure_ghost.bats
@@ -1,0 +1,10 @@
+#/usr/sbin/env bats
+
+source ./src/lib/repo_setup.sh
+
+@test "do nothing if ghost configuration file already exists" {
+	baseDir=tests
+	cp config.production.json.sample tests/config.production.json
+	run configure_ghost $baseDir
+	[[ $output = "doing nothing, the configuration file already exists" ]]
+}

--- a/tests/configure_ghost.bats
+++ b/tests/configure_ghost.bats
@@ -2,9 +2,21 @@
 
 source ./src/lib/repo_setup.sh
 
+setup () {
+	if  [ -f tests/config.production.json ];then
+		rm tests/config.production.json
+	fi
+}
+
 @test "do nothing if ghost configuration file already exists" {
 	baseDir=tests
 	cp config.production.json.sample tests/config.production.json
 	run configure_ghost $baseDir
 	[[ $output = "doing nothing, the configuration file already exists" ]]
+}
+
+@test "copy configuration from sample if no config file exists" {
+	baseDir=tests
+	run configure_ghost $baseDir
+	[ -f tests/config.production.json ]
 }

--- a/tests/create_dir_for_repo.bats
+++ b/tests/create_dir_for_repo.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+# test cases for create_dir_for_repo()
+
 source ./src/lib/repo_setup.sh
 
 setup () {

--- a/tests/create_runtime_dirs.bats
+++ b/tests/create_runtime_dirs.bats
@@ -1,0 +1,17 @@
+#!/usr/sbin/env bats
+
+source ./src/lib/repo_setup.sh
+
+teardown () {
+	if [ -d tests/site ];then
+		rmdir tests/site
+	fi
+}
+
+@test "if site directory exists, do nothing" {
+	baseDir=tests
+	mkdir $baseDir/site
+	run create_runtime_dirs $baseDir
+	[[ $output = "doing nothing, $baseDir/site already exists" ]]
+
+}

--- a/tests/create_runtime_dirs.bats
+++ b/tests/create_runtime_dirs.bats
@@ -31,3 +31,10 @@ teardown () {
 	run create_runtime_dirs $baseDir
 	[[ $output = "doing nothing, $baseDir/stage already exists" ]]
 }
+
+
+@test "if stage directory do not exists, create it" {
+	baseDir=tests
+	run create_runtime_dirs $baseDir
+	[ -d $baseDir/stage ]
+}

--- a/tests/create_runtime_dirs.bats
+++ b/tests/create_runtime_dirs.bats
@@ -6,6 +6,9 @@ teardown () {
 	if [ -d tests/site ];then
 		rmdir tests/site
 	fi
+	if [ -d tests/stage ];then
+		rmdir tests/stage
+	fi
 }
 
 @test "if site directory exists, do nothing" {
@@ -20,4 +23,11 @@ teardown () {
 	baseDir=tests
 	run create_runtime_dirs $baseDir
 	[ -d $baseDir/site ]
+}
+
+@test "if stage directory exists, do nothing" {
+	baseDir=tests
+	mkdir $baseDir/stage
+	run create_runtime_dirs $baseDir
+	[[ $output = "doing nothing, $baseDir/stage already exists" ]]
 }

--- a/tests/create_runtime_dirs.bats
+++ b/tests/create_runtime_dirs.bats
@@ -15,3 +15,9 @@ teardown () {
 	[[ $output = "doing nothing, $baseDir/site already exists" ]]
 
 }
+
+@test "if site directory do not exists, create it" {
+	baseDir=tests
+	run create_runtime_dirs $baseDir
+	[ -d $baseDir/site ]
+}

--- a/tests/pages_repo_setup.bats
+++ b/tests/pages_repo_setup.bats
@@ -13,6 +13,9 @@ teardown () {
 	if [ -d "tests/gitlab" ];then
 		rmdir "tests/gitlab"
 	fi
+	if [ -d "tests/myrepo" ];then
+		rm -rf "tests/myrepo"
+	fi	
 }
 
 @test "noop if local repo exists" {
@@ -24,4 +27,11 @@ teardown () {
 @test "error message and no action taken if local repo does not exist and remote repo variable not filled" {
 	result=$(create_dir_for_repo "tests/something-else")
 	[[ $result =~ "repo cannot be empty" ]]
+}
+
+@test "clone remote repo if local repo does not exist and remote repo exists" {
+	local existingRemoteRepo="https://gitlab.com/gh-rija/ssg-test-output.git"
+	result=$(create_dir_for_repo "tests/myrepo" $existingRemoteRepo)
+	[[ $result =~ "try cloning $existingRemoteRepo" ]]
+	[ -d "tests/myrepo" ]
 }

--- a/tests/pages_repo_setup.bats
+++ b/tests/pages_repo_setup.bats
@@ -35,3 +35,14 @@ teardown () {
 	[[ $result =~ "try cloning $existingRemoteRepo" ]]
 	[ -d "tests/myrepo" ]
 }
+
+@test "error message and no action taken if remote repo cloning fails" {
+	local existingRemoteRepo="https://example.com/gh-rija/ssg-test-output-NOTEXIST.git"
+	run create_dir_for_repo "tests/myrepo" $existingRemoteRepo	
+	[[ "$output" =~ "try cloning $existingRemoteRepo" ]]
+	[ ! -d "tests/myrepo" ]
+	[[ "$output" =~ "fatal: repository" ]]
+	[ $status -ne 0 ]
+
+
+}

--- a/tests/pages_repo_setup.bats
+++ b/tests/pages_repo_setup.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+source ./src/lib/repo_setup.sh
+
+setup () {
+	if [ -d "tests/gitlab" ];then
+		rmdir "tests/gitlab"
+	fi	
+	mkdir "tests/gitlab"
+}
+
+teardown () {
+	if [ -d "tests/gitlab" ];then
+		rmdir "tests/gitlab"
+	fi
+}
+
+@test "noop if local repo exists" {
+	existingRemoteRepo="https://github.com/rija/ghost-ssg.git"
+	result=$(create_dir_for_repo "tests/gitlab" $existingRemoteRepo)
+	[[ $result =~ nothing  ]]
+}

--- a/tests/pages_repo_setup.bats
+++ b/tests/pages_repo_setup.bats
@@ -16,7 +16,12 @@ teardown () {
 }
 
 @test "noop if local repo exists" {
-	existingRemoteRepo="https://github.com/rija/ghost-ssg.git"
+	local existingRemoteRepo="https://github.com/rija/ghost-ssg.git"
 	result=$(create_dir_for_repo "tests/gitlab" $existingRemoteRepo)
-	[[ $result =~ nothing  ]]
+	[[ $result =~ "doing nothing" ]]
+}
+
+@test "error message and no action taken if local repo does not exist and remote repo variable not filled" {
+	result=$(create_dir_for_repo "tests/something-else")
+	[[ $result =~ "repo cannot be empty" ]]
 }


### PR DESCRIPTION
Thank you for contributing to this project, please fill in the form below to describe the change you want to contribute.

## What issue this PR refers to ?

Refs: #1

(Don't leave this empty, first create a relevant Github issue if you don't have one to reference)

## Summary of the changes

This PR implements a setup script for creating the required directories and copying the required configuraration files.
it replaces the manual steps previously described in the README, and also add previously undocumented steps (creating thre runtime directories).

The `./setup` script is a wrapper that call functions defined in a library file: `./src/lib/repo_setup.sh`
comprehenisve unit tests exist under the `./tests` directory as the implementation was done using TDD.

* a12ced3 docs: Update README to use the setup script
* 6049525 feat: create stage dir if not exists and remove it from PAGES_REPO_PATH
* 6fbc1f7 feat: have create_runtime_dirs() do nothing if stage directory exists
* 9a1bc61 feat: have create_runtime_dirs create site dir if it does not exists
* 4c6108e feat: add configure_runtime_dirs() with noop if site dir already exists
* 507326a feat: have configure_env() copy sample env file into base directory
* 602cc1e fix: prevent functions to use variables defined outside scope
* c533561 feat: add configure_env() with noop if .env file already exists
* 70ede8a feat: have configure_ghost() copy sample config to real config
* ca648ad feat: add configure_ghost() function with noop if config already exists
* 20eb353 feat: add remote repo info to README.md
* 4b41411 refactor: scope a test file to a single function to avoid it become big
* bd367a1 feat: add case where remote repo cloning fails
* 1a0e751 fix: add git to CI environment
* 2f1cca0 feat: add case where remote repo is passed and exists
* d35bf33 feat: add case where remote repo is missing
* 7837ed4 feat: add setup script with case where local directory exists already
* 7389f92 feat: add env variable of remote git repo for static  pages publishing
* 828fb00 refactor: store destination branch in an environment variable

## Conformity

  * [x] I have read, understood and agreed to the terms of the CODE_OF_CONDUCT document
  * [x] I have read, understood and agreed to the terms of the CONTRIBUTING document
  * [x] I have read, understood and agreed to the terms of the SECURITY document
  * [x] I have tested thoroughly the changes on my local environment
  
  Additionally, for changes to documentation:
  
  * [x] I have followed the instructions from the updated documentation and it worked as expected
  * [x] I have proof-read the changes to the documentation for typos, grammar, language level
  
  Additionally, for bug fixes:
  
  * [ ] I have reproduced the bug referenced above on my local environment
  * [ ] I have tested that the fix addresses the bug on my local environment
  
  Additionally, for new feature, refactoring or complex bugs:
  
  * [x] I have discussed with the project maintainer the approach and design to the changes prior to implementing them
  * [x] I have obtained agreement from the project maintainer to proceed with said approach and design
  
  

