### PR TITLE
docs: add .editorconfig,.commit-template, mention them in CONRIBUTING.md

### DIFF
--- a/.commit-template
+++ b/.commit-template
@@ -1,0 +1,14 @@
+<type>[optional scope]: <description> (What?, must start with present tense verb)
+
+[begin optional body]
+Why?
+
+How? (when it's not obvious)
+
+Dependencies?
+(If this commit is part of a bigger change that required multiple commits, you can specify the commit hash of the previous commit for that change to help reason on the full change)
+
+[end optional body]
+
+[optional footer(s)]
+Refs: #<issue number>

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset  = utf-8
+
+[{**.*sh,setup,preview,publish,up,down,versions,log,test,whatsup,**.bats}]
+indent_size = tab
+indent_style = tab
+trim_trailing_whitespace = true
+
+
+[**.bats]
+indent_size = tab
+indent_style = tab
+trim_trailing_whitespace = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,33 @@
 # How to contribute ?
 
-* Start in [the issue tracker](https://github.com/rija/ghost-ssg/issues), raise new issues or contribute to existing ones.
+* Start with our issue tracker [1] to see what are the open issues and feel free to raise new issues or contribute to existing ones.
+* This is more like an integration project, make sure you understand what are the pieces and how they fit together
 * When creating a Pull Request, keep it as small as possible and highly focused
 * When creating a Pull Request, do mention which issue number it relates to (only one, no more, no less)
-* When commenting on a Pull Request, use [Conventional Comments](https://conventionalcomments.org/)
-* All commits should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+* When commenting on others' Pull Requests, use Conventional Comments[2]
+* Reach out to the maintainer before trying to make complex changes
+
+## Formatting your commits
+
+* All commits should follow Conventional Commits[3] format
+* commit messages should aim to answer the questions why?, and (for complex changes) how?
+* Sometimes a one line commit message is enough to answer them, but when it's not, format your message as in the `.commit-template` document in this repository
+* You can also configure `git` with that commit template: 
+
+```
+git config commit.template .commit-template
+```
+
+* if it took multiples trial-and-error kind of commits to implement a given unit of change, it's better to combine them together into one commit by squashing [4] them before making a pull request.
+* Try to reference the issue number you are making changes to in your commit message, especially for the main commit that implements the issue, and the last commit before you are ready to make a pull request (see `.commit-template` on how to format that information, which is from Conventional Commits[3]).
+
+
+
+[1] https://github.com/rija/ghost-ssg/issues
+
+[2] https://conventionalcomments.org/
+
+[3] https://www.conventionalcommits.org/en/v1.0.0/
+
+[4] https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
 


### PR DESCRIPTION
Thank you for contributing to this project, please fill in the form below to describe the change you want to contribute.

## What issue this PR refers to ?

Refs: #30

(Don't leave this empty, first create a relevant Github issue if you don't have one to reference)

## Summary of the changes


### .editorconfig

It allow IDEs and editors of contributors to pick up and adopt the prefered formating to use with this project
It's from https://editorconfig.org/

### .commit-template

a commit template for `git commit`, to help making commit messages easily readable and parsable, and helpful to readers.

### CONTRIBUTING.md

Updated that doc to mention the first  two aforementioned. Also reformated the documentation for improved readability and for adding links at the bottom and move everything about formatting commits in their own section.



## Conformity

  * [x] I have read, understood and agreed to the terms of the CODE_OF_CONDUCT document
  * [x] I have read, understood and agreed to the terms of the CONTRIBUTING document
  * [x] I have read, understood and agreed to the terms of the SECURITY document
  * [x] I have tested thoroughly the changes on my local environment
  
  Additionally, for changes to documentation:
  
  * [x] I have followed the instructions from the updated documentation and it worked as expected
  * [x] I have proof-read the changes to the documentation for typos, grammar, language level
  
  Additionally, for bug fixes:
  
  * [ ] I have reproduced the bug referenced above on my local environment
  * [ ] I have tested that the fix addresses the bug on my local environment
  
  Additionally, for new feature, refactoring or complex bugs:
  
  * [ ] I have discussed with the project maintainer the approach and design to the changes prior to implementing them
  * [ ] I have obtained agreement from the project maintainer to proceed with said approach and design
  
  

